### PR TITLE
Updates to use version 1.1.0 of cwms-http-client 

### DIFF
--- a/cumulus-client/build.gradle
+++ b/cumulus-client/build.gradle
@@ -1,9 +1,9 @@
 dependencies {
     implementation(project(":cumulus-model"))
-    implementation("mil.army.usace.hec:cwms-http-client:1.0-SNAPSHOT")
+    implementation("mil.army.usace.hec:cwms-http-client:1.1.0")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.1")
-    testImplementation('mil.army.usace.hec:cwms-http-client:1.0-SNAPSHOT:test-fixtures@jar')
+    testImplementation('mil.army.usace.hec:cwms-http-client:1.1.0:test-fixtures@jar')
 
     testRuntimeOnly('com.squareup.okhttp3:mockwebserver:4.9.2')
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")

--- a/cumulus-client/src/main/java/mil/army/usace/hec/cumulus/client/controllers/WatershedController.java
+++ b/cumulus-client/src/main/java/mil/army/usace/hec/cumulus/client/controllers/WatershedController.java
@@ -1,5 +1,7 @@
 package mil.army.usace.hec.cumulus.client.controllers;
 
+import static mil.army.usace.hec.cumulus.client.controllers.CumulusEndpointConstants.ACCEPT_HEADER_V1;
+
 import java.io.IOException;
 import java.util.List;
 import mil.army.usace.hec.cumulus.client.model.CumulusObjectMapper;
@@ -24,6 +26,8 @@ public class WatershedController {
         throws IOException {
         HttpRequestResponse response =
             new HttpRequestBuilderImpl(apiConnectionInfo, WATERSHEDS_ENDPOINT + "/" + watershedEndpointInput.getWatershedId())
+                .get()
+                .withMediaType(ACCEPT_HEADER_V1)
                 .execute();
         return CumulusObjectMapper.mapJsonToObject(response.getBody(), Watershed.class);
     }
@@ -39,6 +43,8 @@ public class WatershedController {
         throws IOException {
         HttpRequestResponse response =
             new HttpRequestBuilderImpl(apiConnectionInfo, WATERSHEDS_ENDPOINT)
+                .get()
+                .withMediaType(ACCEPT_HEADER_V1)
                 .execute();
         return CumulusObjectMapper.mapJsonToListOfObjects(response.getBody(), Watershed.class);
     }

--- a/cumulus-client/src/test/java/mil/army/usace/hec/cumulus/client/controllers/MockHttpRequestBuilder.java
+++ b/cumulus-client/src/test/java/mil/army/usace/hec/cumulus/client/controllers/MockHttpRequestBuilder.java
@@ -4,7 +4,8 @@ import java.util.HashMap;
 import java.util.Map;
 import mil.army.usace.hec.cwms.http.client.EndpointInput;
 import mil.army.usace.hec.cwms.http.client.HttpRequestBuilder;
-import mil.army.usace.hec.cwms.http.client.HttpRequestResponse;
+import mil.army.usace.hec.cwms.http.client.request.HttpPostRequest;
+import mil.army.usace.hec.cwms.http.client.request.HttpRequestMediaType;
 
 public class MockHttpRequestBuilder implements HttpRequestBuilder {
 
@@ -29,7 +30,12 @@ public class MockHttpRequestBuilder implements HttpRequestBuilder {
     }
 
     @Override
-    public HttpRequestResponse execute() {
+    public HttpPostRequest post() {
+        return null;
+    }
+
+    @Override
+    public HttpRequestMediaType get() {
         return null;
     }
 


### PR DESCRIPTION
Update allows for POST requests and makes GET requests explicit