### PR TITLE
update to the latest cwms-http-client api

### DIFF
--- a/cumulus-client/build.gradle
+++ b/cumulus-client/build.gradle
@@ -1,10 +1,10 @@
 dependencies {
     implementation(project(":cumulus-model"))
     implementation(project(":cwbi-auth-http-client"))
-    implementation("mil.army.usace.hec:cwms-http-client:4.1.2")
+    implementation("mil.army.usace.hec:cwms-http-client:6.4.1")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.1")
-    testImplementation('mil.army.usace.hec:cwms-http-client:4.1.2:test-fixtures@jar')
+    testImplementation('mil.army.usace.hec:cwms-http-client:6.4.1:test-fixtures@jar')
 
     testRuntimeOnly('com.squareup.okhttp3:mockwebserver:4.9.2')
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")

--- a/cumulus-client/src/test/java/mil/army/usace/hec/cumulus/client/controllers/MockHttpRequestBuilder.java
+++ b/cumulus-client/src/test/java/mil/army/usace/hec/cumulus/client/controllers/MockHttpRequestBuilder.java
@@ -3,6 +3,7 @@ package mil.army.usace.hec.cumulus.client.controllers;
 import mil.army.usace.hec.cwms.http.client.EndpointInput;
 import mil.army.usace.hec.cwms.http.client.HttpRequestBuilder;
 import mil.army.usace.hec.cwms.http.client.request.HttpPostRequest;
+import mil.army.usace.hec.cwms.http.client.request.HttpPutRequest;
 import mil.army.usace.hec.cwms.http.client.request.HttpRequestMediaType;
 
 import java.util.HashMap;
@@ -37,6 +38,21 @@ public class MockHttpRequestBuilder implements HttpRequestBuilder {
 
     @Override
     public HttpPostRequest post() {
+        return null;
+    }
+
+    @Override
+    public HttpPutRequest put() {
+        return null;
+    }
+
+    @Override
+    public HttpPostRequest patch() {
+        return null;
+    }
+
+    @Override
+    public HttpRequestMediaType delete() {
         return null;
     }
 

--- a/cumulus-client/src/test/java/mil/army/usace/hec/cumulus/client/controllers/TestController.java
+++ b/cumulus-client/src/test/java/mil/army/usace/hec/cumulus/client/controllers/TestController.java
@@ -31,7 +31,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import mil.army.usace.hec.cwms.htp.client.MockHttpServer;
+import mil.army.usace.hec.cwms.http.client.MockHttpServer;
 import mil.army.usace.hec.cwms.http.client.ApiConnectionInfo;
 import mil.army.usace.hec.cwms.http.client.ApiConnectionInfoBuilder;
 import mil.army.usace.hec.cwms.http.client.auth.OAuth2Token;

--- a/cwbi-auth-http-client/build.gradle
+++ b/cwbi-auth-http-client/build.gradle
@@ -1,9 +1,9 @@
 dependencies {
-    implementation("mil.army.usace.hec:cwms-http-client:4.1.2")
+    implementation("mil.army.usace.hec:cwms-http-client:6.4.1")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.13.0")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
-    testImplementation('mil.army.usace.hec:cwms-http-client:4.1.2:test-fixtures@jar')
+    testImplementation('mil.army.usace.hec:cwms-http-client:6.4.1:test-fixtures@jar')
     testImplementation(platform("com.squareup.okhttp3:okhttp-bom:4.9.2"))
     testImplementation('com.squareup.okhttp3:okhttp:4.9.2')
     testImplementation('com.squareup.okhttp3:mockwebserver:4.9.2')

--- a/cwbi-auth-http-client/src/main/java/hec/army/usace/hec/cwbi/auth/http/client/DirectGrantX509TokenRequestBuilder.java
+++ b/cwbi-auth-http-client/src/main/java/hec/army/usace/hec/cwbi/auth/http/client/DirectGrantX509TokenRequestBuilder.java
@@ -38,7 +38,6 @@ public final class DirectGrantX509TokenRequestBuilder implements DirectGrantX509
             HttpRequestExecutor executor =
                 new HttpRequestBuilderImpl(new ApiConnectionInfoBuilder(getUrl())
                     .withSslSocketData(sslSocketData).build())
-                    .addQueryHeader("Content-Type", MEDIA_TYPE)
                     .post()
                     .withBody(formBody)
                     .withMediaType(MEDIA_TYPE);

--- a/cwbi-auth-http-client/src/main/java/hec/army/usace/hec/cwbi/auth/http/client/RefreshTokenRequestBuilder.java
+++ b/cwbi-auth-http-client/src/main/java/hec/army/usace/hec/cwbi/auth/http/client/RefreshTokenRequestBuilder.java
@@ -30,7 +30,6 @@ public final class RefreshTokenRequestBuilder implements RefreshTokenRequestFlue
             OAuth2Token retVal = null;
             HttpRequestExecutor executor =
                 new HttpRequestBuilderImpl(new ApiConnectionInfoBuilder(getUrl()).build())
-                    .addQueryHeader("Content-Type", MEDIA_TYPE)
                     .post()
                     .withBody(new UrlEncodedFormData()
                         .addRefreshToken(refreshToken)

--- a/cwbi-auth-http-client/src/test/java/hec/army/usace/hec/cwbi/auth/http/client/TestCwbiTokenProvider.java
+++ b/cwbi-auth-http-client/src/test/java/hec/army/usace/hec/cwbi/auth/http/client/TestCwbiTokenProvider.java
@@ -12,7 +12,7 @@ import java.nio.file.Path;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import javax.net.ssl.SSLSocketFactory;
-import mil.army.usace.hec.cwms.htp.client.MockHttpServer;
+import mil.army.usace.hec.cwms.http.client.MockHttpServer;
 import mil.army.usace.hec.cwms.http.client.ApiConnectionInfo;
 import mil.army.usace.hec.cwms.http.client.ApiConnectionInfoBuilder;
 import mil.army.usace.hec.cwms.http.client.auth.OAuth2Token;


### PR DESCRIPTION
fix issue where the Content-Type header was getting added in twice causing Cumulus to fail